### PR TITLE
Release 0.3.4

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "hasInstallScript": true,
       "dependencies": {
         "@inquirer/prompts": "^7.10.1",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "type": "module",
   "private": true,
   "scripts": {

--- a/web/scripts/anonymize.js
+++ b/web/scripts/anonymize.js
@@ -3,14 +3,18 @@ import fs from 'fs';
 import path from 'path';
 
 const envPath = path.resolve('.env');
-let dbUrl = 'file:./dev.db';
+let dbUrl = process.env.DATABASE_URL;
 
-if (fs.existsSync(envPath)) {
+if (!dbUrl && fs.existsSync(envPath)) {
   const envContent = fs.readFileSync(envPath, 'utf8');
   const match = envContent.match(/^DATABASE_URL="(.*)"$/m) || envContent.match(/^DATABASE_URL=(.*)$/m);
   if (match) {
     dbUrl = match[1].replace(/['"]/g, '');
   }
+}
+
+if (!dbUrl) {
+  dbUrl = 'file:./dev.db';
 }
 
 let dbPath;


### PR DESCRIPTION
# Fix Docker Database Anonymization (`v0.3.4`)

### Summary
This PR fixes a critical bug where the "Export Anonymized DB" feature would crash on Docker deployments due to an inability to locate the database file.

### The Issue
Previously, `scripts/anonymize.js` strictly required a physical `.env` file on the hard drive to locate the database path. Because Docker containers pass configuration natively via runtime environment variables rather than local `.env` files, the script would silently fail to find the database URL and default to `dev.db`, crashing the export process.

### The Fix
Updated the `dbUrl` loading logic to dynamically cascade through available environments:
1. **Docker Support:** The script now prioritizes `process.env.DATABASE_URL` first.
2. **PM2/Dev Support:** It safely falls back to manually parsing the local `.env` file if the native environment variable isn't present.
3. **Failsafe:** Defaults to `file:./dev.db` only if neither exists.

This ensures the database anonymization tool works perfectly regardless of how the user chose to deploy Pawbby Reborn!