### PR TITLE
Release 0.3.5

### DIFF
--- a/web/scripts/anonymize.js
+++ b/web/scripts/anonymize.js
@@ -32,7 +32,7 @@ if (dbUrl.startsWith('file:')) {
 }
 
 const src = dbPath;
-const dest = path.resolve('prisma', 'share.db');
+const dest = path.join(path.dirname(src), 'share.db');
 
 if (!fs.existsSync(src)) {
   console.error(`❌ Error: Database not found at ${src}`);
@@ -47,7 +47,7 @@ console.log(`✅ Created a copy of the database: ${dest}`);
 const prisma = new PrismaClient({
   datasources: {
     db: {
-      url: `file:./share.db`
+      url: `file:${dest}`
     }
   }
 });

--- a/web/scripts/anonymize.js
+++ b/web/scripts/anonymize.js
@@ -32,7 +32,7 @@ if (dbUrl.startsWith('file:')) {
 }
 
 const src = dbPath;
-const dest = path.join(path.dirname(src), 'share.db');
+const dest = path.resolve('prisma', 'share.db');
 
 if (!fs.existsSync(src)) {
   console.error(`❌ Error: Database not found at ${src}`);
@@ -47,7 +47,7 @@ console.log(`✅ Created a copy of the database: ${dest}`);
 const prisma = new PrismaClient({
   datasources: {
     db: {
-      url: `file:${path.join(path.dirname(src), 'share.db')}`
+      url: `file:./share.db`
     }
   }
 });

--- a/web/server/api/export-anonymized-db.get.ts
+++ b/web/server/api/export-anonymized-db.get.ts
@@ -32,12 +32,16 @@ export default defineEventHandler(async (event) => {
     isExporting = true
     
     // 1. Run the anonymization script
-    await execPromise('node scripts/anonymize.js', {
+    const { stdout } = await execPromise('node scripts/anonymize.js', {
       cwd: process.cwd()
     })
 
     // 2. Locate the generated share.db
-    const shareDbPath = path.resolve(process.cwd(), 'prisma/share.db')
+    let shareDbPath = path.resolve(process.cwd(), 'prisma/share.db')
+    const match = stdout.match(/👉 You can find the safe file here: (.*)/)
+    if (match && match[1]) {
+      shareDbPath = match[1].trim()
+    }
     
     if (!fs.existsSync(shareDbPath)) {
       throw createError({


### PR DESCRIPTION
`fix: resolve database export pathing issues for Docker, PM2, and NPM environments`

### Description

This PR resolves a critical issue where the database export feature (`/api/export-anonymized-db`) would fail with an `H3Error: Failed to generate anonymized database` due to hardcoded output paths. 

Previously, both the anonymization script and the API handler expected the generated file to be placed exactly at `[cwd]/prisma/share.db`. This caused issues in non-standard execution contexts:
- **Docker**: Write permissions would fail (`EACCES`) when attempting to write to the internal application directory instead of the mounted database volume (e.g. `/data/`).
- **PM2 / NPM**: The `process.cwd()` execution context could mismatch, causing the API to search for the file in the wrong directory entirely.

### Changes Made
- **Dynamic Pathing:** Reverted the `anonymize.js` script to output `share.db` to the exact same directory as the source database (e.g. your mounted volume), guaranteeing write permissions and context stability.
- **Absolute Prisma Connections:** Updated the Prisma connection string in `anonymize.js` to correctly resolve absolute paths to the newly generated database.
- **Stdout Parsing:** Refactored `export-anonymized-db.get.ts` to no longer hardcode the search path for the generated file. It now dynamically parses the script's `stdout` stream to discover the absolute path of `share.db`, entirely bypassing CWD synchronization issues.

### Related Issues
- Fixes export failures for Docker users utilizing custom volume mounts.
- Fixes export failures for PM2/NPM users running the application from outside the standard project root.