### PR TITLE
Release 0.5.4

### DIFF
--- a/upgrade.sh
+++ b/upgrade.sh
@@ -11,7 +11,11 @@ git pull origin main
 # 2. Navigate to web app
 cd web || { echo "❌ Failed to enter 'web' directory"; exit 1; }
 
-# 3. Install new dependencies if any
+# 3. Clear Vite/Nuxt cache to prevent manifest errors
+echo "🧹 Clearing Nuxt cache..."
+npx nuxi clean
+
+# 4. Install new dependencies if any
 echo "📦 Installing any new dependencies..."
 npm install
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "hasInstallScript": true,
       "dependencies": {
         "@inquirer/prompts": "^7.10.1",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "type": "module",
   "private": true,
   "scripts": {


### PR DESCRIPTION
🐛 Bug Fixes

1-Click Auto Updater: Permanently fixed the #app-manifest error that some PM2 users experienced after updating. The background upgrade.sh script will now automatically wipe the stale Nuxt/Vite development cache before building, ensuring flawless updates every time!