### PR TITLE
Release 0.5.5

### DIFF
--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -11,7 +11,11 @@ try {
   envFile.split('\n').forEach(line => {
     const match = line.match(/^([^#=]+)=(.*)$/);
     if (match) {
-      env[match[1].trim()] = match[2].trim().replace(/^["']|["']$/g, '');
+      let val = match[2].trim().replace(/^["']|["']$/g, '');
+      if (match[1].trim() === 'DATABASE_URL' && val.startsWith('file:./')) {
+        val = 'file:' + path.join(__dirname, 'web', val.replace('file:./', ''));
+      }
+      env[match[1].trim()] = val;
     }
   });
 } catch (e) {

--- a/web/app/composables/useApi.ts
+++ b/web/app/composables/useApi.ts
@@ -46,6 +46,8 @@ export interface DeviceLog {
   deviceId: string
   petId?: string
   type: 'toileted' | 'manual-clean' | 'auto-clean' | 'flatten' | 'empty' | 'error' | 'tuya-raw-data' | 'reset-deodorizer'
+  rawTimestamp?: string
+  localDate?: string
   timestamp: string
   description: string
 }

--- a/web/app/pages/litter-box.vue
+++ b/web/app/pages/litter-box.vue
@@ -796,7 +796,7 @@ const getPetLogCount = (petId: string) => {
   return logs.value.filter(l => {
     if (l.petId !== petId) return false
     if (l.type !== 'toileted' && l.type !== 'quick-visit') return false
-    if (selectedDateFilter.value && (!l.rawTimestamp || !l.rawTimestamp.startsWith(selectedDateFilter.value))) return false
+    if (selectedDateFilter.value && l.localDate !== selectedDateFilter.value) return false
     return true
   }).length
 }
@@ -804,7 +804,7 @@ const getPetLogCount = (petId: string) => {
 const getAllLogCount = computed(() => {
   return logs.value.filter(l => {
     if (l.type !== 'toileted' && l.type !== 'quick-visit') return false
-    if (selectedDateFilter.value && (!l.rawTimestamp || !l.rawTimestamp.startsWith(selectedDateFilter.value))) return false
+    if (selectedDateFilter.value && l.localDate !== selectedDateFilter.value) return false
     return true
   }).length
 })
@@ -828,8 +828,8 @@ const minDate = computed(() => {
   if (logs.value && logs.value.length > 0) {
     // The logs are ordered by timestamp descending, so the last log is the oldest
     const oldestLog = logs.value[logs.value.length - 1]
-    if (oldestLog && oldestLog.rawTimestamp) {
-      return oldestLog.rawTimestamp.split('T')[0]
+    if (oldestLog && oldestLog.localDate) {
+      return oldestLog.localDate
     }
   }
   return maxDate.value
@@ -844,7 +844,7 @@ const filteredLogs = computed(() => {
 
     // Date filter logic
     if (selectedDateFilter.value) {
-      if (!log.rawTimestamp || !log.rawTimestamp.startsWith(selectedDateFilter.value)) {
+      if (log.localDate !== selectedDateFilter.value) {
         return false
       }
     }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "hasInstallScript": true,
       "dependencies": {
         "@inquirer/prompts": "^7.10.1",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "type": "module",
   "private": true,
   "scripts": {

--- a/web/server/api/events.ts
+++ b/web/server/api/events.ts
@@ -110,11 +110,15 @@ export default defineEventHandler(async (event) => {
 
     const timeZone = user?.timezone || 'UTC'
     let timestampStr = ''
+    let localDateStr = ''
     try {
       timestampStr = new Date(e.timestamp).toLocaleString('en-US', { month: 'numeric', day: 'numeric', hour: '2-digit', minute: '2-digit', hour12: false, timeZone })
+      const formatter = new Intl.DateTimeFormat('en-CA', { timeZone, year: 'numeric', month: '2-digit', day: '2-digit' })
+      localDateStr = formatter.format(new Date(e.timestamp))
     } catch (err) {
       // Fallback if invalid timezone string
       timestampStr = new Date(e.timestamp).toLocaleString('en-US', { month: 'numeric', day: 'numeric', hour: '2-digit', minute: '2-digit', hour12: false })
+      localDateStr = e.timestamp.toISOString().split('T')[0]
     }
 
     return {
@@ -123,6 +127,7 @@ export default defineEventHandler(async (event) => {
       petId: e.petId,
       type: e.type,
       rawTimestamp: e.timestamp.toISOString(),
+      localDate: localDateStr,
       // Format to MM/DD HH:mm
       timestamp: timestampStr,
       description


### PR DESCRIPTION
🐛 Bug Fixes
PM2 SQLite Database Path Resolution: Fixed a critical bug in ecosystem.config.cjs that caused bare-metal PM2 installations to fail when adding new devices. Previously, the production Nuxt server was resolving the relative dev.db path incorrectly, causing it to read/write to an empty shadow database hidden inside the .output folder instead of the user's actual database. The SQLite database is now locked via an absolute path, ensuring PM2 and db push are always perfectly synced.
Timezone Accuracy on Detailed Records: Fixed an issue where the "Detailed Records" log grouping and date filtering were incorrectly defaulting to UTC time. Events are now properly bucketed based on the custom timezone you set in your Settings page, ensuring late-night logs no longer accidentally spill over into the next day.
Type Safety: Added rawTimestamp and localDate tracking to the DeviceLog TypeScript interfaces for cleaner frontend data mapping.