### PR TITLE
feat: Home Assistant integration (REST state API + MQTT auto-discovery)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,24 @@ _(Alternatively, you can still update PM2 manually by running `./upgrade.sh` fro
 
 ---
 
+## 🏠 Home Assistant Integration
+
+Pawbby Reborn exposes a local REST API so you can pull your litter box into Home Assistant — no cloud, no custom component.
+
+1. Open the **Settings** tab and generate an **API Key**.
+2. Open **API Documentation** in the dashboard for a ready-to-paste `configuration.yaml` snippet.
+3. It uses Home Assistant's built-in `rest` integration to create sensors (status, waste bin, litter level, visits today, last visit weight/pet, deodorizer life, plus online/lid-open/bin-full binary sensors) and `rest_command`s to trigger **clean**, **flatten**, and **empty**.
+
+The key endpoints (all authenticate with `Authorization: Bearer YOUR_API_KEY`):
+
+| Method | Endpoint               | Purpose                               |
+| :----- | :--------------------- | :------------------------------------ |
+| `GET`  | `/api/external/state`  | Current device state (for HA sensors) |
+| `GET`  | `/api/external/events` | Recent event history                  |
+| `POST` | `/api/external/action` | Trigger `clean` / `flatten` / `empty` |
+
+---
+
 ## 📤 Sharing Your Database for Development
 
 Because the dashboard saves the raw Tuya JSON payloads from your litter box directly into the database, sharing your database with the developers is incredibly helpful for finding missing commands (like the remote auto-clean trigger).

--- a/web/app/composables/useApi.ts
+++ b/web/app/composables/useApi.ts
@@ -10,6 +10,12 @@ export interface User {
   webhookUrl?: string
   timezone?: string
   apiKey?: string
+  mqttEnabled?: boolean
+  mqttHost?: string
+  mqttPort?: number
+  mqttUsername?: string
+  mqttPassword?: string
+  mqttBaseTopic?: string
 }
 
 export interface Pet {

--- a/web/app/pages/api-docs.vue
+++ b/web/app/pages/api-docs.vue
@@ -66,6 +66,134 @@ curl "http://YOUR_PAWBBY_IP:3333/api/external/events?deviceId=device_id_here&lim
   -H "Authorization: Bearer YOUR_API_KEY"
         </div>
       </section>
+
+      <section class="bg-black/20 rounded-2xl p-6 border border-white/5">
+        <h2 class="text-lg font-bold mb-4 text-pawbby-primary">Get Live State</h2>
+        <div class="flex items-center gap-3 mb-4">
+          <span class="bg-[#3D7A41]/20 text-[#3D7A41] px-2 py-1 rounded font-bold text-xs">GET</span>
+          <code class="text-sm font-mono">/api/external/state</code>
+        </div>
+        <p class="text-sm text-pawbby-muted mb-4">Returns the current state of a device (status, waste bin, litter level, last visit, deodorizer). Ideal for polling from Home Assistant. Omit <code class="text-white/80">deviceId</code> to receive an array of all devices.</p>
+
+        <h3 class="font-bold text-sm mb-2 text-white/80">Query Parameters</h3>
+        <ul class="list-disc pl-5 text-sm text-pawbby-muted mb-4 space-y-2">
+          <li><code class="text-white/80">deviceId</code> (optional) - The ID of your device. If omitted, all devices are returned under a <code class="text-white/80">devices</code> array.</li>
+        </ul>
+
+        <h3 class="font-bold text-sm mb-2 text-white/80">Example Response</h3>
+        <div class="bg-black/50 rounded-xl p-4 text-sm font-mono text-white/80 overflow-x-auto mb-4 whitespace-pre" v-pre>
+{
+  "id": "device_id_here",
+  "name": "Litter Box",
+  "deviceId": "tuya-abc-123",
+  "mode": "local",
+  "online": true,
+  "status": "Ready",
+  "wasteBin": "Normal",
+  "litterLevel": "Sufficient*",
+  "lidOpen": false,
+  "binRemoved": false,
+  "todayToileted": 3,
+  "latestWeight": 4.15,
+  "lastVisitPet": "Milo",
+  "lastVisitAt": "2026-07-22T20:21:45.000Z",
+  "deodorizerActive": true,
+  "deodorizerDaysLeft": 21,
+  "lastHeartbeat": "2026-07-22T20:31:45.000Z",
+  "pets": [
+    {
+      "id": "pet_id_here",
+      "name": "Milo",
+      "profileWeight": 4.2,
+      "lastUsedAt": "2026-07-22T20:21:45.000Z",
+      "latestWeight": 4.15,
+      "lastDuration": 95,
+      "visitsToday": 2
+    }
+  ]
+}
+        </div>
+        <p class="text-xs text-pawbby-muted mb-4">The <code class="text-white/80">pets</code> array lists every cat with raw datapoints: last visit time, latest visit weight (kg), last visit duration (seconds) and visits today. These are intentionally raw — Home Assistant keeps long-term statistics, so you can build weight/duration trends yourself with a statistics or derivative helper. Over MQTT, each cat is published as its own Home Assistant device automatically (the weight and duration sensors use <code class="text-white/80">state_class: measurement</code> so HA records their history).</p>
+
+        <h3 class="font-bold text-sm mb-2 text-white/80">Example cURL</h3>
+        <div class="bg-black/50 rounded-xl p-4 text-sm font-mono text-white/80 overflow-x-auto whitespace-pre">
+curl "http://YOUR_PAWBBY_IP:3333/api/external/state?deviceId=device_id_here" \
+  -H "Authorization: Bearer YOUR_API_KEY"
+        </div>
+      </section>
+
+      <section class="bg-black/20 rounded-2xl p-6 border border-white/5">
+        <h2 class="text-lg font-bold mb-4 text-pawbby-primary">🏠 Home Assistant</h2>
+        <p class="text-sm text-pawbby-muted mb-4">Pawbby Reborn works with Home Assistant out of the box using the built-in <code class="bg-white/10 px-1 rounded text-white/90">rest</code> integration — no custom component required. Add the following to your <code class="bg-white/10 px-1 rounded text-white/90">configuration.yaml</code>, replacing <code class="text-white/80">YOUR_PAWBBY_IP</code>, <code class="text-white/80">YOUR_DEVICE_ID</code> and <code class="text-white/80">YOUR_API_KEY</code>, then restart Home Assistant.</p>
+
+        <h3 class="font-bold text-sm mb-2 text-white/80">Sensors (polls live state)</h3>
+        <div class="bg-black/50 rounded-xl p-4 text-sm font-mono text-white/80 overflow-x-auto mb-4 whitespace-pre" v-pre>
+rest:
+  - resource: "http://YOUR_PAWBBY_IP:3333/api/external/state?deviceId=YOUR_DEVICE_ID"
+    scan_interval: 60
+    headers:
+      Authorization: "Bearer YOUR_API_KEY"
+    sensor:
+      - name: "Litter Box Status"
+        value_template: "{{ value_json.status }}"
+      - name: "Litter Box Waste Bin"
+        value_template: "{{ value_json.wasteBin }}"
+      - name: "Litter Box Litter Level"
+        value_template: "{{ value_json.litterLevel }}"
+      - name: "Litter Box Visits Today"
+        value_template: "{{ value_json.todayToileted }}"
+        unit_of_measurement: "visits"
+        state_class: total_increasing
+      - name: "Litter Box Last Visit Weight"
+        value_template: "{{ value_json.latestWeight }}"
+        unit_of_measurement: "kg"
+        device_class: weight
+        state_class: measurement
+      - name: "Litter Box Last Visit Pet"
+        value_template: "{{ value_json.lastVisitPet }}"
+      - name: "Litter Box Deodorizer Days Left"
+        value_template: "{{ value_json.deodorizerDaysLeft }}"
+        unit_of_measurement: "days"
+    binary_sensor:
+      - name: "Litter Box Online"
+        value_template: "{{ 'on' if value_json.online else 'off' }}"
+        device_class: connectivity
+      - name: "Litter Box Lid Open"
+        value_template: "{{ 'on' if value_json.lidOpen else 'off' }}"
+        device_class: opening
+      - name: "Litter Box Waste Bin Full"
+        value_template: "{{ 'on' if value_json.wasteBin == 'Full' else 'off' }}"
+        device_class: problem
+        </div>
+
+        <h3 class="font-bold text-sm mb-2 text-white/80">Buttons (trigger actions)</h3>
+        <div class="bg-black/50 rounded-xl p-4 text-sm font-mono text-white/80 overflow-x-auto mb-4 whitespace-pre" v-pre>
+rest_command:
+  pawbby_clean:
+    url: "http://YOUR_PAWBBY_IP:3333/api/external/action"
+    method: POST
+    headers:
+      Authorization: "Bearer YOUR_API_KEY"
+      Content-Type: "application/json"
+    payload: '{"deviceId": "YOUR_DEVICE_ID", "action": "clean"}'
+  pawbby_flatten:
+    url: "http://YOUR_PAWBBY_IP:3333/api/external/action"
+    method: POST
+    headers:
+      Authorization: "Bearer YOUR_API_KEY"
+      Content-Type: "application/json"
+    payload: '{"deviceId": "YOUR_DEVICE_ID", "action": "flatten"}'
+  pawbby_empty:
+    url: "http://YOUR_PAWBBY_IP:3333/api/external/action"
+    method: POST
+    headers:
+      Authorization: "Bearer YOUR_API_KEY"
+      Content-Type: "application/json"
+    payload: '{"deviceId": "YOUR_DEVICE_ID", "action": "empty"}'
+        </div>
+        <p class="text-xs text-pawbby-muted">Call the commands from an automation or a <code class="text-white/80">script</code> via <code class="text-white/80">service: rest_command.pawbby_flatten</code>. Home Assistant must be able to reach Pawbby over your local network. <code class="text-white/80">WEBHOOK_STRICT_MODE</code> only affects outbound webhooks, not this inbound API.</p>
+        <p class="text-xs text-[#D84C4C]/90 mt-2">⚠️ Note: <code class="text-white/80">flatten</code> (straighten litter) and <code class="text-white/80">empty</code> are fully supported. <code class="text-white/80">clean</code> is not yet implemented — its device payload hasn't been reverse-engineered, so the command is currently a no-op (and is omitted from the MQTT buttons).</p>
+      </section>
     </div>
   </div>
 </template>

--- a/web/app/pages/settings.vue
+++ b/web/app/pages/settings.vue
@@ -142,6 +142,22 @@
         </div>
       </button>
 
+      <!-- Home Assistant (MQTT) -->
+      <button @click="showMqttModal = true" class="w-full flex items-center justify-between text-white/90 hover:text-white group">
+        <div class="flex items-center space-x-4">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-pawbby-muted" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M3 12l9-9 9 9M5 10v10a1 1 0 001 1h4v-6h4v6h4a1 1 0 001-1V10" />
+          </svg>
+          <span class="font-medium text-lg">Home Assistant (MQTT)</span>
+        </div>
+        <div class="flex items-center space-x-2">
+          <span class="text-sm text-pawbby-mutedDark group-hover:text-pawbby-muted transition-colors">{{ user?.mqttEnabled ? 'Enabled' : 'Setup' }}</span>
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-pawbby-mutedDark group-hover:text-pawbby-muted transition-colors" viewBox="0 0 20 20" fill="currentColor">
+            <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd" />
+          </svg>
+        </div>
+      </button>
+
       <!-- Check for Updates -->
       <button @click="handleUpdateClick"
         class="w-full flex items-center justify-between text-white/90 hover:text-white group">
@@ -304,6 +320,58 @@
         </div>
         <div class="mt-6">
           <button @click="showNotificationsModal = false"
+            class="w-full py-3 bg-white/5 text-white font-bold rounded-xl hover:bg-white/10 transition-colors">
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Home Assistant (MQTT) Modal -->
+    <div v-if="showMqttModal" class="fixed inset-0 bg-black/80 z-50 flex items-center justify-center p-4">
+      <div class="bg-pawbby-card rounded-3xl p-6 w-full max-w-sm border border-white/10 relative overflow-hidden animate-fade-in-up max-h-[90vh] overflow-y-auto no-scrollbar">
+        <h3 class="text-xl font-bold text-white mb-2">Home Assistant (MQTT)</h3>
+        <p class="text-xs text-pawbby-muted mb-6">Publish your litter box to Home Assistant via MQTT auto-discovery. Entities (sensors + action buttons) appear automatically — no YAML required. Point this at your broker (e.g. the Mosquitto add-on).</p>
+        <div v-if="user" class="space-y-4">
+          <label class="flex items-center justify-between text-sm text-white/90 cursor-pointer">
+            <span class="font-medium">Enable MQTT Bridge</span>
+            <input type="checkbox" v-model="user.mqttEnabled" @change="saveMqttSettings" class="accent-pawbby-primary w-5 h-5 rounded" />
+          </label>
+          <div>
+            <label class="block text-sm text-pawbby-muted mb-1">Broker Host</label>
+            <input v-model="user.mqttHost" @change="saveMqttSettings" type="text" placeholder="192.168.1.10 or homeassistant.local"
+              class="w-full bg-black/30 border border-white/10 rounded-xl px-4 py-3 text-sm text-white focus:outline-none focus:border-pawbby-primary" />
+          </div>
+          <div class="flex gap-3">
+            <div class="flex-1">
+              <label class="block text-sm text-pawbby-muted mb-1">Port</label>
+              <input v-model.number="user.mqttPort" @change="saveMqttSettings" type="number" placeholder="1883"
+                class="w-full bg-black/30 border border-white/10 rounded-xl px-4 py-3 text-sm text-white focus:outline-none focus:border-pawbby-primary" />
+            </div>
+            <div class="flex-1">
+              <label class="block text-sm text-pawbby-muted mb-1">Base Topic</label>
+              <input v-model="user.mqttBaseTopic" @change="saveMqttSettings" type="text" placeholder="pawbby"
+                class="w-full bg-black/30 border border-white/10 rounded-xl px-4 py-3 text-sm text-white focus:outline-none focus:border-pawbby-primary" />
+            </div>
+          </div>
+          <div>
+            <label class="block text-sm text-pawbby-muted mb-1">Username <span class="text-pawbby-mutedDark">(optional)</span></label>
+            <input v-model="user.mqttUsername" @change="saveMqttSettings" type="text" autocomplete="off"
+              class="w-full bg-black/30 border border-white/10 rounded-xl px-4 py-3 text-sm text-white focus:outline-none focus:border-pawbby-primary" />
+          </div>
+          <div>
+            <label class="block text-sm text-pawbby-muted mb-1">Password <span class="text-pawbby-mutedDark">(optional)</span></label>
+            <input v-model="user.mqttPassword" @change="saveMqttSettings" type="password" autocomplete="new-password"
+              class="w-full bg-black/30 border border-white/10 rounded-xl px-4 py-3 text-sm text-white focus:outline-none focus:border-pawbby-primary" />
+          </div>
+
+          <button @click="testMqtt" :disabled="testingMqtt || !user.mqttHost"
+            class="w-full py-3 bg-pawbby-primary/10 text-[#3D7A41] font-semibold rounded-xl hover:bg-pawbby-primary/20 transition-colors disabled:opacity-50 text-sm">
+            {{ testingMqtt ? 'Testing...' : 'Test Connection' }}
+          </button>
+        </div>
+        <div class="mt-6">
+          <button @click="showMqttModal = false"
             class="w-full py-3 bg-white/5 text-white font-bold rounded-xl hover:bg-white/10 transition-colors">
             Close
           </button>
@@ -574,6 +642,8 @@ const checkForUpdates = async (silent = false) => {
 
 const webhookUrl = ref('')
 const testingWebhook = ref(false)
+const showMqttModal = ref(false)
+const testingMqtt = ref(false)
 const showNotificationsModal = ref(false)
 const showNotificationControlsModal = ref(false)
 const showTimezoneModal = ref(false)
@@ -637,6 +707,44 @@ const testWebhook = async () => {
     alert('Failed to send test notification. Check the URL.')
   } finally {
     testingWebhook.value = false
+  }
+}
+
+const saveMqttSettings = async () => {
+  if (!user.value) return
+  await api.updateUser({
+    mqttEnabled: user.value.mqttEnabled,
+    mqttHost: user.value.mqttHost,
+    mqttPort: user.value.mqttPort,
+    mqttUsername: user.value.mqttUsername,
+    mqttPassword: user.value.mqttPassword,
+    mqttBaseTopic: user.value.mqttBaseTopic
+  })
+}
+
+const testMqtt = async () => {
+  if (!user.value?.mqttHost) return
+  testingMqtt.value = true
+  try {
+    const res = await fetch('/api/mqtt/test', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        mqttHost: user.value.mqttHost,
+        mqttPort: user.value.mqttPort,
+        mqttUsername: user.value.mqttUsername,
+        mqttPassword: user.value.mqttPassword
+      })
+    })
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}))
+      throw new Error(err.statusMessage || 'Connection failed')
+    }
+    alert('Successfully connected to the MQTT broker!')
+  } catch (e: any) {
+    alert('Failed to connect: ' + (e?.message || 'Check host, port and credentials.'))
+  } finally {
+    testingMqtt.value = false
   }
 }
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -12,6 +12,7 @@
         "@inquirer/prompts": "^7.10.1",
         "@prisma/client": "^6.19.3",
         "chart.js": "^4.5.1",
+        "mqtt": "^5.15.2",
         "nuxt": "^4.4.8",
         "spark-md5": "^3.0.2",
         "tuyapi": "^7.7.1",
@@ -388,6 +389,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -4052,20 +4062,6 @@
         "giget": "dist/cli.mjs"
       }
     },
-    "node_modules/@prisma/config/node_modules/magicast": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
-      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/parser": "^7.25.4",
-        "@babel/types": "^7.25.4",
-        "source-map-js": "^1.2.0"
-      }
-    },
     "node_modules/@prisma/config/node_modules/perfect-debounce": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
@@ -5018,6 +5014,24 @@
       "integrity": "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==",
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/readable-stream": {
+      "version": "4.0.24",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.24.tgz",
+      "integrity": "sha512-NRvUNC/JFGPJvqdAfEve8oginbM6V08u5NzLWpG8MwA2kTPOLnqk+wpwuPT+mp3aUsxyuT6m2gnrPuHYCruzEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
@@ -5036,6 +5050,15 @@
       "integrity": "sha512-lWf05dnD42DLVKQJZrDHtWFidcLrHuip01CtnC2/S6AMhX4t9ZlEUj4iuRlAnts0PQk7KESOqKxeGE/b6sIPGg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@unhead/vue": {
       "version": "2.1.15",
@@ -5897,6 +5920,18 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/bl": {
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-6.1.6.tgz",
+      "integrity": "sha512-jLsPgN/YSvPUg9UX0Kd73CXpm2Psg9FxMeCSXnk3WBO3CMT10JMwijubhGfHCnFu6TPn1ei3b975dxv7K2pWVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/readable-stream": "^4.0.0",
+        "buffer": "^6.0.3",
+        "inherits": "^2.0.4",
+        "readable-stream": "^4.2.0"
+      }
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -5925,6 +5960,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/broker-factory": {
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/broker-factory/-/broker-factory-3.1.15.tgz",
+      "integrity": "sha512-ko+aWvgNuP49meGrdjUu7rC+Y+Wai3cCPxP3xWwHsHfehFjOh5ZQM2yC4gEB2UddeZ/YXhm0K1eG/L6fxym2Og==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.7",
+        "fast-unique-numbers": "^9.0.27",
+        "tslib": "^2.8.1",
+        "worker-factory": "^7.0.50"
       }
     },
     "node_modules/browserslist": {
@@ -6314,6 +6361,12 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/commist": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/commist/-/commist-3.2.0.tgz",
+      "integrity": "sha512-4PIMoPniho+LqXmpS5d3NuGYncG6XWlkBSVGiWycL22dd42OYdUGil2CWuzklaJoNxyxUSpO4MKIBU94viWNAw==",
+      "license": "MIT"
+    },
     "node_modules/commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -6360,6 +6413,35 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/concat-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/confbox": {
       "version": "0.2.4",
@@ -7340,6 +7422,19 @@
         "fast-string-truncated-width": "^3.0.2"
       }
     },
+    "node_modules/fast-unique-numbers": {
+      "version": "9.0.27",
+      "resolved": "https://registry.npmjs.org/fast-unique-numbers/-/fast-unique-numbers-9.0.27.tgz",
+      "integrity": "sha512-nDA9ADeINN8SA2u2wCtU+siWFTTDqQR37XvgPIDDmboWQeExz7X0mImxuaN+kJddliIqy2FpVRmnvRZ+j8i1/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.2.0"
+      }
+    },
     "node_modules/fast-wrap-ansi": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
@@ -7774,6 +7869,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/help-me": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "license": "MIT"
+    },
     "node_modules/hookable": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.1.1.tgz",
@@ -8000,6 +8101,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ioredis"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/iron-webcrypto": {
@@ -8269,6 +8379,16 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-sdsl": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
+      "integrity": "sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
       }
     },
     "node_modules/js-tokens": {
@@ -9124,6 +9244,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
@@ -9179,6 +9308,55 @@
       "resolved": "https://registry.npmjs.org/mocked-exports/-/mocked-exports-0.1.1.tgz",
       "integrity": "sha512-aF7yRQr/Q0O2/4pIXm6PZ5G+jAd7QS4Yu8m+WEeEHGnbo+7mE36CbLSDQiXYV8bVL3NfmdeqPJct0tUlnjVSnA==",
       "license": "MIT"
+    },
+    "node_modules/mqtt": {
+      "version": "5.15.2",
+      "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-5.15.2.tgz",
+      "integrity": "sha512-VWZU2CSUY3U3oN0PSBRDE5SNsFi4zqqNeQ/uv3pZWqY3CrBXD/dhd0ZLjlsk5YnebGlrapi4lRVNJPUNQ5aZ3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/readable-stream": "^4.0.21",
+        "@types/ws": "^8.18.1",
+        "commist": "^3.2.0",
+        "concat-stream": "^2.0.0",
+        "debug": "^4.4.1",
+        "help-me": "^5.0.0",
+        "lru-cache": "^10.4.3",
+        "minimist": "^1.2.8",
+        "mqtt-packet": "^9.0.2",
+        "number-allocator": "^1.0.14",
+        "readable-stream": "^4.7.0",
+        "rfdc": "^1.4.1",
+        "socks": "^2.8.6",
+        "split2": "^4.2.0",
+        "worker-timers": "^8.0.23",
+        "ws": "^8.18.3"
+      },
+      "bin": {
+        "mqtt": "build/bin/mqtt.js",
+        "mqtt_pub": "build/bin/pub.js",
+        "mqtt_sub": "build/bin/sub.js"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/mqtt-packet": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-9.0.2.tgz",
+      "integrity": "sha512-MvIY0B8/qjq7bKxdN1eD+nrljoeaai+qjLJgfRn3TiMuz0pamsIWY2bFODPZMSNmabsLANXsLl4EMoWvlaTZWA==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^6.0.8",
+        "debug": "^4.3.4",
+        "process-nextick-args": "^2.0.1"
+      }
+    },
+    "node_modules/mqtt/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
     },
     "node_modules/mrmime": {
       "version": "2.0.1",
@@ -9489,6 +9667,16 @@
       },
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/number-allocator": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/number-allocator/-/number-allocator-1.0.14.tgz",
+      "integrity": "sha512-OrL44UTVAvkKdOdRQZIJpLkAdjXGTRda052sN4sO77bKEzYYqWKMBjQvrJFzqygI99gL6Z4u2xctPW1tB8ErvA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "js-sdsl": "4.3.0"
       }
     },
     "node_modules/nuxt": {
@@ -11245,6 +11433,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "license": "MIT"
+    },
     "node_modules/rolldown": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.2.tgz",
@@ -11647,6 +11841,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
     "node_modules/smob": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/smob/-/smob-1.6.2.tgz",
@@ -11654,6 +11858,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
       }
     },
     "node_modules/source-map": {
@@ -11698,6 +11916,15 @@
       "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-3.0.2.tgz",
       "integrity": "sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==",
       "license": "(WTFPL OR MIT)"
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
     },
     "node_modules/srvx": {
       "version": "0.11.17",
@@ -12414,8 +12641,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/tsscmp": {
       "version": "1.0.6",
@@ -12497,6 +12723,12 @@
       "integrity": "sha512-wTk4DH3cxwk196uGLK/E9pE45aLfeKJacKmcEgEOA/q5dnPGNxXt0cfYdFxb57L+sEpf1oJH4Dnx/pnRcku9jg==",
       "license": "MIT"
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/ufo": {
       "version": "1.6.4",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
@@ -12550,6 +12782,12 @@
       "engines": {
         "node": ">=18.12.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "license": "MIT"
     },
     "node_modules/unenv": {
       "version": "2.0.0-rc.24",
@@ -13952,6 +14190,53 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/worker-factory": {
+      "version": "7.0.50",
+      "resolved": "https://registry.npmjs.org/worker-factory/-/worker-factory-7.0.50.tgz",
+      "integrity": "sha512-hhwc0G+sFwM4qBuhJIUBn2p1Jf8v/FwmLUANBf/Q+Lt2uI8mfIZQhXaZQACodQD4R7Zp6cn/6702bIvNn2puJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.7",
+        "fast-unique-numbers": "^9.0.27",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/worker-timers": {
+      "version": "8.0.34",
+      "resolved": "https://registry.npmjs.org/worker-timers/-/worker-timers-8.0.34.tgz",
+      "integrity": "sha512-WXL+Dqsm0G6dnC66rQsvM3tPT2adhbqSirWUCZGglkALOr8ocS0KlpU0iuKbjflJOlu3ydZikMEVrYnHOM9suw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.7",
+        "tslib": "^2.8.1",
+        "worker-timers-broker": "^8.0.18",
+        "worker-timers-worker": "^9.0.15"
+      }
+    },
+    "node_modules/worker-timers-broker": {
+      "version": "8.0.18",
+      "resolved": "https://registry.npmjs.org/worker-timers-broker/-/worker-timers-broker-8.0.18.tgz",
+      "integrity": "sha512-FrjzDVX1wKfZN0gRbCFqv8VHuTncG4sbI/WGEg4tSSQeIsnwqg4YBYWMAHYLJtUDEYYmiK65UKFrVMVk2irDSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.7",
+        "broker-factory": "^3.1.15",
+        "fast-unique-numbers": "^9.0.27",
+        "tslib": "^2.8.1",
+        "worker-timers-worker": "^9.0.15"
+      }
+    },
+    "node_modules/worker-timers-worker": {
+      "version": "9.0.15",
+      "resolved": "https://registry.npmjs.org/worker-timers-worker/-/worker-timers-worker-9.0.15.tgz",
+      "integrity": "sha512-KKUe7lZ/Aignr51H6hOUik8LwTnIgojH/1lwhli8A8qIEIyewogZTpNpMW5B6BF7nmwBOkUoTYgf1H3QShcjSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.7",
+        "tslib": "^2.8.1",
+        "worker-factory": "^7.0.50"
       }
     },
     "node_modules/wrap-ansi": {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "hasInstallScript": true,
       "dependencies": {
         "@inquirer/prompts": "^7.10.1",
@@ -4060,6 +4060,20 @@
       },
       "bin": {
         "giget": "dist/cli.mjs"
+      }
+    },
+    "node_modules/@prisma/config/node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
       }
     },
     "node_modules/@prisma/config/node_modules/perfect-debounce": {

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "private": true,
   "scripts": {

--- a/web/package.json
+++ b/web/package.json
@@ -17,6 +17,7 @@
     "@inquirer/prompts": "^7.10.1",
     "@prisma/client": "^6.19.3",
     "chart.js": "^4.5.1",
+    "mqtt": "^5.15.2",
     "nuxt": "^4.4.8",
     "spark-md5": "^3.0.2",
     "tuyapi": "^7.7.1",

--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -32,6 +32,13 @@ model User {
   notifyDashError       Boolean @default(true)
   
   apiKey                String?
+
+  mqttEnabled           Boolean @default(false)
+  mqttHost              String?
+  mqttPort              Int?     @default(1883)
+  mqttUsername          String?
+  mqttPassword          String?
+  mqttBaseTopic         String?  @default("pawbby")
 }
 
 model Pet {

--- a/web/server/api/devices.ts
+++ b/web/server/api/devices.ts
@@ -1,4 +1,5 @@
 import prisma from "../utils/prisma";
+import { computeDeviceState } from "../utils/deviceState";
 
 export default defineEventHandler(async (event) => {
   const method = getMethod(event);
@@ -7,170 +8,11 @@ export default defineEventHandler(async (event) => {
     const devices = await prisma.device.findMany();
     const devicesWithHeartbeat = await Promise.all(
       devices.map(async (d) => {
-        const latestRaw = await prisma.litterEvent.findFirst({
-          where: { deviceId: d.id, type: "tuya-raw-data" },
-          orderBy: { timestamp: "desc" },
-        });
-
-        const today = new Date();
-        today.setHours(0, 0, 0, 0);
-
-        const todayToileted = await prisma.litterEvent.count({
-          where: {
-            deviceId: d.id,
-            type: "toileted",
-            timestamp: { gte: today },
-          },
-        });
-
-        let wasteBin = "Normal";
-        let litterLevel = "Sufficient*";
-        let status = "Ready";
-        let lidOpen = false;
-
-        // Find the most recent raw data that contains DP 102 (clean cycle count/fault code)
-        const latestDP102Event = await prisma.litterEvent.findFirst({
-          where: {
-            deviceId: d.id,
-            type: "tuya-raw-data",
-            rawData: { contains: '"102"' },
-          },
-          orderBy: { timestamp: "desc" },
-        });
-
-        if (latestDP102Event && latestDP102Event.rawData) {
-          try {
-            const parsed = JSON.parse(latestDP102Event.rawData);
-            if (parsed && parsed.dps && parsed.dps["102"]) {
-              const base64Str = parsed.dps["102"];
-              if (typeof base64Str === "string") {
-                const buffer = Buffer.from(base64Str, "base64");
-                // If bytes 1 or 2 indicate a fault code, we can assume it's the insufficient litter error
-                if (buffer.length > 2 && (buffer[1] > 0 || buffer[2] > 0)) {
-                  litterLevel = "Insufficient*";
-                }
-              }
-            }
-          } catch (e) {}
-        }
-
-        // Check DP 114 for motor/sensor errors
-        const latestDP114Event = await prisma.litterEvent.findFirst({
-          where: {
-            deviceId: d.id,
-            type: "tuya-raw-data",
-            rawData: { contains: '"114"' },
-          },
-          orderBy: { timestamp: "desc" },
-        });
-        if (latestDP114Event && latestDP114Event.rawData) {
-          try {
-            const parsed = JSON.parse(latestDP114Event.rawData);
-            if (parsed && parsed.dps && parsed.dps["114"]) {
-              const dp114 = String(parsed.dps["114"]).toLowerCase();
-              if (dp114 !== "motor_ok") {
-                litterLevel = "Insufficient*";
-              }
-            }
-          } catch (e) {}
-        }
-
-        // Check DP 112 for low weight
-        const latestDP112Event = await prisma.litterEvent.findFirst({
-          where: {
-            deviceId: d.id,
-            type: "tuya-raw-data",
-            rawData: { contains: '"112"' },
-          },
-          orderBy: { timestamp: "desc" },
-        });
-        if (latestDP112Event && latestDP112Event.rawData) {
-          try {
-            const parsed = JSON.parse(latestDP112Event.rawData);
-            if (parsed && parsed.dps && parsed.dps["112"] !== undefined) {
-              const weight = Number(parsed.dps["112"]);
-              if (weight > 0 && weight < 1500) {
-                litterLevel = "Insufficient*";
-              }
-            }
-          } catch (e) {}
-        }
-
-        let binRemoved = false;
-
-        // Check for persistent Bin Full state
-        const latestCollectFull = await prisma.litterEvent.findFirst({
-          where: {
-            deviceId: d.id,
-            type: "tuya-raw-data",
-            rawData: { contains: '"collect_full"' },
-          },
-          orderBy: { timestamp: "desc" },
-        });
-        const latestBinReplaced = await prisma.litterEvent.findFirst({
-          where: { deviceId: d.id, type: "bin-replaced" },
-          orderBy: { timestamp: "desc" },
-        });
-
-        let isBinFullState = false;
-        if (latestCollectFull) {
-          const fullTime = latestCollectFull.timestamp.getTime();
-          const replacedTime = latestBinReplaced
-            ? latestBinReplaced.timestamp.getTime()
-            : 0;
-          if (fullTime > replacedTime) {
-            isBinFullState = true;
-          }
-        }
-
-        // Check DP 116 for status
-        const latestDP116Event = await prisma.litterEvent.findFirst({
-          where: {
-            deviceId: d.id,
-            type: "tuya-raw-data",
-            rawData: { contains: '"116"' },
-          },
-          orderBy: { timestamp: "desc" },
-        });
-        if (latestDP116Event && latestDP116Event.rawData) {
-          try {
-            const parsed = JSON.parse(latestDP116Event.rawData);
-            if (parsed && parsed.dps && parsed.dps["116"]) {
-              const dp116 = String(parsed.dps["116"]);
-              if (dp116 === "lid_open") {
-                status = "Lid Open";
-                lidOpen = true;
-              } else if (dp116 === "collect_install") {
-                status = "Bin Removed";
-                binRemoved = true;
-              } else if (dp116 === "collect_full") {
-                status = "Bin Full";
-                wasteBin = "Full";
-              } else if (dp116 !== "work_idle") {
-                status = "Busy";
-              }
-            }
-          } catch (e) {}
-        }
-
-        // Override status if the bin is persistently full (and not currently removed or open)
-        if (isBinFullState) {
-          wasteBin = "Full";
-          if (!lidOpen && !binRemoved && status === "Ready") {
-            status = "Bin Full";
-          }
-        }
-
+        const state = await computeDeviceState(d);
         return {
           ...d,
           tuyaClientSecret: d.tuyaClientSecret ? '********' : null,
-          status,
-          lidOpen,
-          binRemoved,
-          todayToileted,
-          lastHeartbeat: latestRaw ? latestRaw.timestamp : null,
-          wasteBin,
-          litterLevel,
+          ...state,
         };
       }),
     );
@@ -197,6 +39,7 @@ export default defineEventHandler(async (event) => {
     // Restart daemon
     const nitro = useNitroApp();
     await nitro.hooks.callHook("tuya:restart" as any);
+    await nitro.hooks.callHook("mqtt:refresh" as any);
 
     return { device };
   }
@@ -220,6 +63,7 @@ export default defineEventHandler(async (event) => {
     // Restart daemon
     const nitro = useNitroApp();
     await nitro.hooks.callHook("tuya:restart" as any);
+    await nitro.hooks.callHook("mqtt:refresh" as any);
 
     return { device };
   }
@@ -231,6 +75,7 @@ export default defineEventHandler(async (event) => {
       // Restart daemon
       const nitro = useNitroApp();
       await nitro.hooks.callHook("tuya:restart" as any);
+      await nitro.hooks.callHook("mqtt:refresh" as any);
       return { success: true };
     }
   }

--- a/web/server/api/external/state.get.ts
+++ b/web/server/api/external/state.get.ts
@@ -1,0 +1,66 @@
+import prisma from '../../utils/prisma'
+import { computeDeviceState } from '../../utils/deviceState'
+import { computePetStates } from '../../utils/petState'
+
+// Consider a device "online" if it has reported to us within the last 15 minutes
+// (the listener sends a keepalive ping every 5 minutes).
+const ONLINE_WINDOW_MS = 15 * 60 * 1000
+
+function shape(device: any, state: Awaited<ReturnType<typeof computeDeviceState>>) {
+  const online = !!state.lastHeartbeat && Date.now() - new Date(state.lastHeartbeat).getTime() < ONLINE_WINDOW_MS
+  return {
+    id: device.id,
+    name: device.name,
+    deviceId: device.deviceId,
+    mode: device.mode,
+    online,
+    status: state.status,
+    wasteBin: state.wasteBin,
+    litterLevel: state.litterLevel,
+    lidOpen: state.lidOpen,
+    binRemoved: state.binRemoved,
+    todayToileted: state.todayToileted,
+    latestWeight: state.latestWeight,
+    lastVisitPet: state.lastVisitPet,
+    lastVisitAt: state.lastVisitAt,
+    deodorizerActive: state.deodorizerActive,
+    deodorizerDaysLeft: state.deodorizerDaysLeft,
+    lastHeartbeat: state.lastHeartbeat,
+  }
+}
+
+export default defineEventHandler(async (event) => {
+  const authHeader = getHeader(event, 'authorization')
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized: Missing or invalid Authorization header. Provide token as Bearer <key>' })
+  }
+
+  const apiKey = authHeader.split(' ')[1]
+  const user = await prisma.user.findFirst({ where: { apiKey } })
+
+  if (!user) {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized: Invalid API Key' })
+  }
+
+  const query = getQuery(event)
+  const deviceId = query.deviceId as string | undefined
+
+  // Cats are global to the install (not device-scoped), so they are included alongside.
+  const pets = await computePetStates()
+
+  // Single device (Home Assistant REST sensors point at one resource)
+  if (deviceId) {
+    const device = await prisma.device.findUnique({ where: { id: deviceId } })
+    if (!device) {
+      throw createError({ statusCode: 404, statusMessage: `Device '${deviceId}' not found` })
+    }
+    return { ...shape(device, await computeDeviceState(device)), pets }
+  }
+
+  // All devices
+  const devices = await prisma.device.findMany()
+  const result = await Promise.all(
+    devices.map(async (d) => shape(d, await computeDeviceState(d))),
+  )
+  return { devices: result, pets }
+})

--- a/web/server/api/mqtt/test.post.ts
+++ b/web/server/api/mqtt/test.post.ts
@@ -1,0 +1,42 @@
+import mqtt from 'mqtt'
+
+// Attempts a short-lived connection to the configured broker so the user can verify
+// their settings from the dashboard. Session-authed (not under /api/external).
+export default defineEventHandler(async (event) => {
+  const body = await readBody(event)
+  const { mqttHost, mqttPort, mqttUsername, mqttPassword } = body || {}
+
+  if (!mqttHost) {
+    throw createError({ statusCode: 400, statusMessage: 'MQTT host is required' })
+  }
+
+  const port = Number(mqttPort) || 1883
+  const url = `mqtt://${mqttHost}:${port}`
+
+  return await new Promise((resolve, reject) => {
+    let settled = false
+    const client = mqtt.connect(url, {
+      username: mqttUsername || undefined,
+      password: mqttPassword || undefined,
+      connectTimeout: 5000,
+      reconnectPeriod: 0, // don't retry — this is a one-shot test
+    })
+
+    const finish = (errMsg?: string) => {
+      if (settled) return
+      settled = true
+      try {
+        client.end(true)
+      } catch (e) {}
+      if (errMsg) {
+        reject(createError({ statusCode: 500, statusMessage: errMsg }))
+      } else {
+        resolve({ success: true })
+      }
+    }
+
+    client.on('connect', () => finish())
+    client.on('error', (e) => finish(e.message || 'Connection failed'))
+    setTimeout(() => finish('Connection timed out'), 6000)
+  })
+})

--- a/web/server/api/pets.ts
+++ b/web/server/api/pets.ts
@@ -1,5 +1,8 @@
 import prisma from '../utils/prisma'
 
+// Refresh MQTT/HA entities (cats map to Home Assistant devices) after a change.
+const refreshMqtt = () => useNitroApp().hooks.callHook('mqtt:refresh' as any)
+
 export default defineEventHandler(async (event) => {
   const method = event.method
 
@@ -12,16 +15,18 @@ export default defineEventHandler(async (event) => {
     const { name, birthDate, weight, imageBase64 } = body
     const safeData = { name, birthDate, weight, imageBase64 }
 
-    if (body.id) {
-       return await prisma.pet.update({ where: { id: body.id }, data: safeData })
-    }
-    return await prisma.pet.create({ data: safeData })
+    const result = body.id
+      ? await prisma.pet.update({ where: { id: body.id }, data: safeData })
+      : await prisma.pet.create({ data: safeData })
+    await refreshMqtt()
+    return result
   }
-  
+
   if (method === 'DELETE') {
     const query = getQuery(event)
     if (query.id) {
       await prisma.pet.delete({ where: { id: String(query.id) } })
+      await refreshMqtt()
     }
     return { success: true }
   }

--- a/web/server/api/settings.ts
+++ b/web/server/api/settings.ts
@@ -16,23 +16,39 @@ export default defineEventHandler(async (event) => {
     
     if (body.user) {
       // Destructure to prevent mass assignment vulnerabilities
-      const { 
+      const {
         name, email, weightUnit, webhookUrl, timezone,
         notifyPushVisit, notifyPushAutoClean, notifyPushManualClean, notifyPushEmpty, notifyPushFlatten, notifyPushError,
-        notifyDashVisit, notifyDashAutoClean, notifyDashManualClean, notifyDashEmpty, notifyDashFlatten, notifyDashError
+        notifyDashVisit, notifyDashAutoClean, notifyDashManualClean, notifyDashEmpty, notifyDashFlatten, notifyDashError,
+        mqttEnabled, mqttHost, mqttPort, mqttUsername, mqttPassword, mqttBaseTopic
       } = body.user
-      
-      const safeData = { 
+
+      // Coerce port to an Int (or null). Leave undefined so unchanged fields are skipped.
+      let mqttPortValue: number | null | undefined = mqttPort
+      if (mqttPort !== undefined) {
+        mqttPortValue = mqttPort === null || mqttPort === '' ? null : Number(mqttPort)
+      }
+
+      const safeData = {
         name, email, weightUnit, webhookUrl, timezone,
         notifyPushVisit, notifyPushAutoClean, notifyPushManualClean, notifyPushEmpty, notifyPushFlatten, notifyPushError,
-        notifyDashVisit, notifyDashAutoClean, notifyDashManualClean, notifyDashEmpty, notifyDashFlatten, notifyDashError
+        notifyDashVisit, notifyDashAutoClean, notifyDashManualClean, notifyDashEmpty, notifyDashFlatten, notifyDashError,
+        mqttEnabled, mqttHost, mqttPort: mqttPortValue, mqttUsername, mqttPassword, mqttBaseTopic
       }
-      
+
       const user = await prisma.user.findFirst()
       if (user) {
         await prisma.user.update({ where: { id: user.id }, data: safeData })
       } else {
         await prisma.user.create({ data: safeData })
+      }
+
+      // Reconnect the MQTT bridge only when MQTT settings actually changed, so
+      // unrelated saves (timezone, notifications, ...) don't blip Home Assistant.
+      const mqttKeys = ['mqttEnabled', 'mqttHost', 'mqttPort', 'mqttUsername', 'mqttPassword', 'mqttBaseTopic']
+      if (mqttKeys.some((k) => k in body.user)) {
+        const nitro = useNitroApp()
+        await nitro.hooks.callHook('mqtt:restart' as any)
       }
     }
     return { success: true }

--- a/web/server/middleware/auth.ts
+++ b/web/server/middleware/auth.ts
@@ -15,6 +15,13 @@ export default defineEventHandler(async (event) => {
     return
   }
 
+  // 4. The external API (Home Assistant & other integrations) authenticates with a
+  // Bearer API key inside each handler, not the dashboard session cookie. Let it
+  // through here so that Bearer check can actually run.
+  if (event.path.startsWith('/api/external/')) {
+    return
+  }
+
   // 4. Verify the session
   const sessionConfig = {
     password: process.env.SESSION_PASSWORD || 'pawbby-reborn-local-secret-32-chars!',

--- a/web/server/plugins/mqtt-bridge.ts
+++ b/web/server/plugins/mqtt-bridge.ts
@@ -1,0 +1,336 @@
+import mqtt from 'mqtt'
+import type { MqttClient } from 'mqtt'
+import prisma from '../utils/prisma'
+import { computeDeviceState } from '../utils/deviceState'
+import { computePetStates } from '../utils/petState'
+
+// Bridges Pawbby Reborn to Home Assistant over MQTT using HA's discovery protocol.
+// When enabled, entities (sensors, binary sensors, action buttons) appear in Home
+// Assistant automatically under one "Pawbby" device per litter box — no YAML needed.
+export default defineNitroPlugin((nitroApp) => {
+  const DISCOVERY_PREFIX = 'homeassistant'
+  const ALLOWED_ACTIONS = ['clean', 'flatten', 'empty']
+  const ONLINE_WINDOW_MS = 15 * 60 * 1000
+
+  let client: MqttClient | null = null
+  let periodic: NodeJS.Timeout | null = null
+  let baseTopic = 'pawbby'
+
+  const availabilityTopic = () => `${baseTopic}/bridge/availability`
+  const stateTopic = (id: string) => `${baseTopic}/${id}/state`
+  const commandTopic = (id: string, action: string) => `${baseTopic}/${id}/command/${action}`
+  const petStateTopic = (id: string) => `${baseTopic}/pet/${id}/state`
+
+  const SENSORS = [
+    { key: 'status', name: 'Status', tpl: '{{ value_json.status }}', icon: 'mdi:information-outline' },
+    { key: 'waste_bin', name: 'Waste Bin', tpl: '{{ value_json.wasteBin }}', icon: 'mdi:delete' },
+    { key: 'litter_level', name: 'Litter Level', tpl: '{{ value_json.litterLevel }}', icon: 'mdi:dots-grid' },
+    { key: 'visits_today', name: 'Visits Today', tpl: '{{ value_json.todayToileted }}', unit: 'visits', state_class: 'total_increasing', icon: 'mdi:cat' },
+    { key: 'last_weight', name: 'Last Visit Weight', tpl: '{{ value_json.latestWeight }}', unit: 'kg', device_class: 'weight', state_class: 'measurement' },
+    { key: 'last_pet', name: 'Last Visit Pet', tpl: '{{ value_json.lastVisitPet }}', icon: 'mdi:paw' },
+    { key: 'deodorizer_days', name: 'Deodorizer Days Left', tpl: '{{ value_json.deodorizerDaysLeft }}', unit: 'days', icon: 'mdi:air-filter' },
+  ] as const
+
+  const BINARY = [
+    { key: 'online', name: 'Online', tpl: "{{ 'on' if value_json.online else 'off' }}", device_class: 'connectivity' },
+    { key: 'lid_open', name: 'Lid Open', tpl: "{{ 'on' if value_json.lidOpen else 'off' }}", device_class: 'opening' },
+    { key: 'bin_full', name: 'Waste Bin Full', tpl: "{{ 'on' if value_json.wasteBin == 'Full' else 'off' }}", device_class: 'problem' },
+    { key: 'bin_removed', name: 'Bin Removed', tpl: "{{ 'on' if value_json.binRemoved else 'off' }}", device_class: 'problem' },
+  ] as const
+
+  // Only actions the daemon can actually perform are exposed as buttons. "clean" is
+  // intentionally omitted — its Tuya payload is not yet known (no-op in tuya-listener).
+  const BUTTONS = [
+    { key: 'flatten', name: 'Flatten', action: 'flatten', icon: 'mdi:road-variant' },
+    { key: 'empty', name: 'Empty', action: 'empty', icon: 'mdi:delete-empty' },
+  ] as const
+
+  // Per-cat sensors — each cat becomes its own Home Assistant device. Only raw
+  // datapoints are published; state_class:measurement lets HA keep long-term
+  // statistics so you can build weight/duration trends natively.
+  const PET_SENSORS = [
+    { key: 'last_used', name: 'Last Used', tpl: '{{ value_json.lastUsedAt }}', device_class: 'timestamp' },
+    { key: 'weight', name: 'Weight', tpl: '{{ value_json.latestWeight }}', unit: 'kg', device_class: 'weight', state_class: 'measurement' },
+    { key: 'last_duration', name: 'Last Duration', tpl: '{{ value_json.lastDuration }}', unit: 's', device_class: 'duration', state_class: 'measurement' },
+    { key: 'visits_today', name: 'Visits Today', tpl: '{{ value_json.visitsToday }}', unit: 'visits', state_class: 'total_increasing', icon: 'mdi:paw' },
+  ] as const
+
+  const petDeviceBlock = (pet: { id: string; name: string }) => ({
+    identifiers: [`pawbby_pet_${pet.id}`],
+    name: pet.name,
+    manufacturer: 'Pawbby Reborn',
+    model: 'Cat',
+  })
+
+  const deviceBlock = (device: any) => ({
+    identifiers: [`pawbby_${device.id}`],
+    name: device.name || 'Pawbby Litter Box',
+    manufacturer: 'Pawbby Reborn',
+    model: 'Smart Litter Box',
+  })
+
+  const shapeState = (device: any, state: Awaited<ReturnType<typeof computeDeviceState>>) => {
+    const online = !!state.lastHeartbeat && Date.now() - new Date(state.lastHeartbeat).getTime() < ONLINE_WINDOW_MS
+    return {
+      online,
+      status: state.status,
+      wasteBin: state.wasteBin,
+      litterLevel: state.litterLevel,
+      lidOpen: state.lidOpen,
+      binRemoved: state.binRemoved,
+      todayToileted: state.todayToileted,
+      latestWeight: state.latestWeight,
+      lastVisitPet: state.lastVisitPet,
+      lastVisitAt: state.lastVisitAt,
+      deodorizerActive: state.deodorizerActive,
+      deodorizerDaysLeft: state.deodorizerDaysLeft,
+      lastHeartbeat: state.lastHeartbeat,
+    }
+  }
+
+  const availabilityFields = {
+    availability_topic: '', // filled per publish (baseTopic may change)
+    payload_available: 'online',
+    payload_not_available: 'offline',
+  }
+
+  const publishDiscovery = async () => {
+    if (!client) return
+    const devices = await prisma.device.findMany()
+    for (const device of devices) {
+      const dev = deviceBlock(device)
+      const avail = { ...availabilityFields, availability_topic: availabilityTopic() }
+
+      for (const s of SENSORS) {
+        const cfg: any = {
+          name: s.name,
+          unique_id: `pawbby_${device.id}_${s.key}`,
+          object_id: `pawbby_${device.name}_${s.key}`.toLowerCase().replace(/[^a-z0-9_]+/g, '_'),
+          state_topic: stateTopic(device.id),
+          value_template: s.tpl,
+          device: dev,
+          ...avail,
+        }
+        if ('unit' in s && s.unit) cfg.unit_of_measurement = s.unit
+        if ('device_class' in s && s.device_class) cfg.device_class = s.device_class
+        if ('state_class' in s && s.state_class) cfg.state_class = s.state_class
+        if ('icon' in s && s.icon) cfg.icon = s.icon
+        client.publish(
+          `${DISCOVERY_PREFIX}/sensor/pawbby_${device.id}/${s.key}/config`,
+          JSON.stringify(cfg),
+          { retain: true },
+        )
+      }
+
+      for (const b of BINARY) {
+        const cfg: any = {
+          name: b.name,
+          unique_id: `pawbby_${device.id}_${b.key}`,
+          object_id: `pawbby_${device.name}_${b.key}`.toLowerCase().replace(/[^a-z0-9_]+/g, '_'),
+          state_topic: stateTopic(device.id),
+          value_template: b.tpl,
+          payload_on: 'on',
+          payload_off: 'off',
+          device_class: b.device_class,
+          device: dev,
+          ...avail,
+        }
+        client.publish(
+          `${DISCOVERY_PREFIX}/binary_sensor/pawbby_${device.id}/${b.key}/config`,
+          JSON.stringify(cfg),
+          { retain: true },
+        )
+      }
+
+      for (const btn of BUTTONS) {
+        const cfg: any = {
+          name: btn.name,
+          unique_id: `pawbby_${device.id}_btn_${btn.key}`,
+          object_id: `pawbby_${device.name}_${btn.key}`.toLowerCase().replace(/[^a-z0-9_]+/g, '_'),
+          command_topic: commandTopic(device.id, btn.action),
+          payload_press: 'PRESS',
+          icon: btn.icon,
+          device: dev,
+          ...avail,
+        }
+        client.publish(
+          `${DISCOVERY_PREFIX}/button/pawbby_${device.id}/${btn.key}/config`,
+          JSON.stringify(cfg),
+          { retain: true },
+        )
+      }
+    }
+  }
+
+  const publishState = async (deviceId?: string) => {
+    if (!client) return
+    const devices = deviceId
+      ? await prisma.device.findMany({ where: { id: deviceId } })
+      : await prisma.device.findMany()
+    for (const device of devices) {
+      const state = await computeDeviceState(device)
+      client.publish(stateTopic(device.id), JSON.stringify(shapeState(device, state)), { retain: true })
+    }
+  }
+
+  const publishPetDiscovery = async () => {
+    if (!client) return
+    const pets = await prisma.pet.findMany()
+    const avail = { ...availabilityFields, availability_topic: availabilityTopic() }
+    for (const pet of pets) {
+      const dev = petDeviceBlock(pet)
+      for (const s of PET_SENSORS) {
+        const cfg: any = {
+          name: s.name,
+          unique_id: `pawbby_pet_${pet.id}_${s.key}`,
+          object_id: `pawbby_${pet.name}_${s.key}`.toLowerCase().replace(/[^a-z0-9_]+/g, '_'),
+          state_topic: petStateTopic(pet.id),
+          value_template: s.tpl,
+          device: dev,
+          ...avail,
+        }
+        if ('unit' in s && s.unit) cfg.unit_of_measurement = s.unit
+        if ('device_class' in s && s.device_class) cfg.device_class = s.device_class
+        if ('state_class' in s && s.state_class) cfg.state_class = s.state_class
+        if ('icon' in s && s.icon) cfg.icon = s.icon
+        client.publish(
+          `${DISCOVERY_PREFIX}/sensor/pawbby_pet_${pet.id}/${s.key}/config`,
+          JSON.stringify(cfg),
+          { retain: true },
+        )
+      }
+    }
+  }
+
+  const publishPetState = async () => {
+    if (!client) return
+    const pets = await computePetStates()
+    for (const pet of pets) {
+      // A timestamp sensor rejects null; publish empty so HA shows "unknown" instead.
+      const payload = {
+        name: pet.name,
+        lastUsedAt: pet.lastUsedAt ?? '',
+        latestWeight: pet.latestWeight,
+        lastDuration: pet.lastDuration,
+        visitsToday: pet.visitsToday,
+      }
+      client.publish(petStateTopic(pet.id), JSON.stringify(payload), { retain: true })
+    }
+  }
+
+  const handleCommand = async (topic: string, payload: Buffer) => {
+    // Expected: <baseTopic>/<deviceId>/command/<action>
+    const prefix = `${baseTopic}/`
+    if (!topic.startsWith(prefix)) return
+    const parts = topic.slice(prefix.length).split('/')
+    if (parts.length !== 3 || parts[1] !== 'command') return
+    const [deviceId, , action] = parts
+    if (!ALLOWED_ACTIONS.includes(action)) {
+      console.warn(`[MQTT] Ignoring unknown action '${action}'`)
+      return
+    }
+    console.log(`[MQTT] Command received: ${action} -> device ${deviceId}`)
+    try {
+      await nitroApp.hooks.callHook('tuya:action' as any, { deviceId, action })
+    } catch (e: any) {
+      console.error('[MQTT] Failed to dispatch action:', e?.message)
+    }
+  }
+
+  const stop = () => {
+    if (periodic) {
+      clearInterval(periodic)
+      periodic = null
+    }
+    if (client) {
+      try {
+        client.end(true)
+      } catch (e) {}
+      client = null
+    }
+  }
+
+  const start = async () => {
+    stop()
+
+    const user = await prisma.user.findFirst()
+    if (!user?.mqttEnabled || !user.mqttHost) return
+
+    baseTopic = user.mqttBaseTopic || 'pawbby'
+    const port = user.mqttPort || 1883
+    const url = `mqtt://${user.mqttHost}:${port}`
+
+    console.log(`[MQTT] Connecting to broker ${url} ...`)
+
+    client = mqtt.connect(url, {
+      username: user.mqttUsername || undefined,
+      password: user.mqttPassword || undefined,
+      reconnectPeriod: 5000,
+      connectTimeout: 10000,
+      will: {
+        topic: availabilityTopic(),
+        payload: 'offline',
+        retain: true,
+        qos: 0,
+      },
+    })
+
+    client.on('connect', async () => {
+      console.log('[MQTT] Connected to broker.')
+      client!.publish(availabilityTopic(), 'online', { retain: true })
+      client!.subscribe(`${baseTopic}/+/command/+`)
+      try {
+        await publishDiscovery()
+        await publishPetDiscovery()
+        await publishState()
+        await publishPetState()
+      } catch (e: any) {
+        console.error('[MQTT] Initial publish failed:', e?.message)
+      }
+      if (!periodic) {
+        periodic = setInterval(() => {
+          publishState().catch((e) => console.error('[MQTT] Periodic publish failed:', e?.message))
+          publishPetState().catch((e) => console.error('[MQTT] Periodic pet publish failed:', e?.message))
+        }, 30000)
+      }
+    })
+
+    client.on('message', (topic, payload) => {
+      handleCommand(topic, payload).catch((e) => console.error('[MQTT] Command handler error:', e?.message))
+    })
+
+    client.on('error', (err) => {
+      console.error('[MQTT] Client error:', err.message)
+    })
+  }
+
+  // Reconnect / disconnect when the user changes MQTT settings.
+  nitroApp.hooks.hook('mqtt:restart' as any, () => {
+    console.log('[MQTT] Restarting bridge due to config change...')
+    start()
+  })
+
+  // Re-publish discovery + state without reconnecting (e.g. a cat or device was
+  // added/removed) so new entities appear in Home Assistant promptly.
+  nitroApp.hooks.hook('mqtt:refresh' as any, async () => {
+    if (!client?.connected) return
+    try {
+      await publishDiscovery()
+      await publishPetDiscovery()
+      await publishState()
+      await publishPetState()
+    } catch (e: any) {
+      console.error('[MQTT] Refresh failed:', e?.message)
+    }
+  })
+
+  // Push fresh state the moment the Tuya listener sees a change (a visit also
+  // updates the relevant cat's last-used / weight / visit count).
+  nitroApp.hooks.hook('device:state-changed' as any, ({ deviceId }: any) => {
+    publishState(deviceId).catch((e) => console.error('[MQTT] State push failed:', e?.message))
+    publishPetState().catch((e) => console.error('[MQTT] Pet state push failed:', e?.message))
+  })
+
+  // Start slightly after the Tuya listener so devices are known.
+  setTimeout(() => start().catch((e) => console.error('[MQTT] Startup failed:', e?.message)), 2000)
+})

--- a/web/server/plugins/tuya-listener.ts
+++ b/web/server/plugins/tuya-listener.ts
@@ -421,6 +421,10 @@ export default defineNitroPlugin((nitroApp) => {
 
           if (stateChanged) {
             deviceStates.set(config.id, state);
+            // Let integrations (e.g. the MQTT bridge) push fresh state immediately.
+            nitroApp.hooks.callHook("device:state-changed" as any, {
+              deviceId: config.id,
+            });
           }
         };
 

--- a/web/server/utils/deviceState.ts
+++ b/web/server/utils/deviceState.ts
@@ -1,0 +1,182 @@
+import prisma from './prisma'
+
+export interface DeviceLiveState {
+  status: string // "Ready" | "Busy" | "Lid Open" | "Bin Removed" | "Bin Full"
+  wasteBin: string // "Normal" | "Full"
+  litterLevel: string // "Sufficient*" | "Insufficient*"
+  lidOpen: boolean
+  binRemoved: boolean
+  todayToileted: number
+  lastHeartbeat: Date | null
+  latestWeight: number | null // kg, from the most recent completed visit
+  lastVisitPet: string | null // pet name, or null if unidentified/none
+  lastVisitAt: Date | null
+  deodorizerActive: boolean
+  deodorizerDaysLeft: number | null
+}
+
+/**
+ * Derive the current human-readable state of a litter box from the raw Tuya payloads
+ * we have logged. This is the single source of truth shared by the dashboard
+ * (`/api/devices`) and the external API (`/api/external/state`, e.g. Home Assistant).
+ */
+export async function computeDeviceState(device: {
+  id: string
+  deodorizerLastReset?: Date | null
+  deodorizerDuration?: number
+}): Promise<DeviceLiveState> {
+  const deviceId = device.id
+
+  const latestRaw = await prisma.litterEvent.findFirst({
+    where: { deviceId, type: 'tuya-raw-data' },
+    orderBy: { timestamp: 'desc' },
+  })
+
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+
+  const todayToileted = await prisma.litterEvent.count({
+    where: { deviceId, type: 'toileted', timestamp: { gte: today } },
+  })
+
+  let wasteBin = 'Normal'
+  let litterLevel = 'Sufficient*'
+  let status = 'Ready'
+  let lidOpen = false
+
+  // Find the most recent raw data that contains DP 102 (clean cycle count/fault code)
+  const latestDP102Event = await prisma.litterEvent.findFirst({
+    where: { deviceId, type: 'tuya-raw-data', rawData: { contains: '"102"' } },
+    orderBy: { timestamp: 'desc' },
+  })
+  if (latestDP102Event?.rawData) {
+    try {
+      const parsed = JSON.parse(latestDP102Event.rawData)
+      const base64Str = parsed?.dps?.['102']
+      if (typeof base64Str === 'string') {
+        const buffer = Buffer.from(base64Str, 'base64')
+        // If bytes 1 or 2 indicate a fault code, assume it's the insufficient litter error
+        if (buffer.length > 2 && (buffer[1] > 0 || buffer[2] > 0)) {
+          litterLevel = 'Insufficient*'
+        }
+      }
+    } catch (e) {}
+  }
+
+  // Check DP 114 for motor/sensor errors
+  const latestDP114Event = await prisma.litterEvent.findFirst({
+    where: { deviceId, type: 'tuya-raw-data', rawData: { contains: '"114"' } },
+    orderBy: { timestamp: 'desc' },
+  })
+  if (latestDP114Event?.rawData) {
+    try {
+      const parsed = JSON.parse(latestDP114Event.rawData)
+      if (parsed?.dps?.['114']) {
+        const dp114 = String(parsed.dps['114']).toLowerCase()
+        if (dp114 !== 'motor_ok') litterLevel = 'Insufficient*'
+      }
+    } catch (e) {}
+  }
+
+  // Check DP 112 for low weight
+  const latestDP112Event = await prisma.litterEvent.findFirst({
+    where: { deviceId, type: 'tuya-raw-data', rawData: { contains: '"112"' } },
+    orderBy: { timestamp: 'desc' },
+  })
+  if (latestDP112Event?.rawData) {
+    try {
+      const parsed = JSON.parse(latestDP112Event.rawData)
+      if (parsed?.dps?.['112'] !== undefined) {
+        const weight = Number(parsed.dps['112'])
+        if (weight > 0 && weight < 1500) litterLevel = 'Insufficient*'
+      }
+    } catch (e) {}
+  }
+
+  let binRemoved = false
+
+  // Check for persistent Bin Full state
+  const latestCollectFull = await prisma.litterEvent.findFirst({
+    where: { deviceId, type: 'tuya-raw-data', rawData: { contains: '"collect_full"' } },
+    orderBy: { timestamp: 'desc' },
+  })
+  const latestBinReplaced = await prisma.litterEvent.findFirst({
+    where: { deviceId, type: 'bin-replaced' },
+    orderBy: { timestamp: 'desc' },
+  })
+
+  let isBinFullState = false
+  if (latestCollectFull) {
+    const fullTime = latestCollectFull.timestamp.getTime()
+    const replacedTime = latestBinReplaced ? latestBinReplaced.timestamp.getTime() : 0
+    if (fullTime > replacedTime) isBinFullState = true
+  }
+
+  // Check DP 116 for status
+  const latestDP116Event = await prisma.litterEvent.findFirst({
+    where: { deviceId, type: 'tuya-raw-data', rawData: { contains: '"116"' } },
+    orderBy: { timestamp: 'desc' },
+  })
+  if (latestDP116Event?.rawData) {
+    try {
+      const parsed = JSON.parse(latestDP116Event.rawData)
+      if (parsed?.dps?.['116']) {
+        const dp116 = String(parsed.dps['116'])
+        if (dp116 === 'lid_open') {
+          status = 'Lid Open'
+          lidOpen = true
+        } else if (dp116 === 'collect_install') {
+          status = 'Bin Removed'
+          binRemoved = true
+        } else if (dp116 === 'collect_full') {
+          status = 'Bin Full'
+          wasteBin = 'Full'
+        } else if (dp116 !== 'work_idle') {
+          status = 'Busy'
+        }
+      }
+    } catch (e) {}
+  }
+
+  // Override status if the bin is persistently full (and not currently removed or open)
+  if (isBinFullState) {
+    wasteBin = 'Full'
+    if (!lidOpen && !binRemoved && status === 'Ready') status = 'Bin Full'
+  }
+
+  // Most recent completed visit (weight + which pet)
+  const lastVisit = await prisma.litterEvent.findFirst({
+    where: { deviceId, type: 'toileted' },
+    orderBy: { timestamp: 'desc' },
+  })
+  let lastVisitPet: string | null = null
+  if (lastVisit?.petId) {
+    const pet = await prisma.pet.findUnique({ where: { id: lastVisit.petId } })
+    lastVisitPet = pet?.name ?? null
+  }
+
+  // Deodorizer life remaining
+  let deodorizerActive = false
+  let deodorizerDaysLeft: number | null = null
+  if (device.deodorizerLastReset) {
+    const duration = device.deodorizerDuration ?? 30
+    const elapsedDays = (Date.now() - new Date(device.deodorizerLastReset).getTime()) / 86400000
+    deodorizerDaysLeft = Math.max(0, Math.round(duration - elapsedDays))
+    deodorizerActive = deodorizerDaysLeft > 0
+  }
+
+  return {
+    status,
+    wasteBin,
+    litterLevel,
+    lidOpen,
+    binRemoved,
+    todayToileted,
+    lastHeartbeat: latestRaw ? latestRaw.timestamp : null,
+    latestWeight: lastVisit?.weight ?? null,
+    lastVisitPet,
+    lastVisitAt: lastVisit?.timestamp ?? null,
+    deodorizerActive,
+    deodorizerDaysLeft,
+  }
+}

--- a/web/server/utils/petState.ts
+++ b/web/server/utils/petState.ts
@@ -1,0 +1,50 @@
+import prisma from './prisma'
+
+export interface PetLiveState {
+  id: string
+  name: string
+  profileWeight: number // the weight set on the cat's profile (used for PawID matching)
+  lastUsedAt: Date | null // most recent litter box visit
+  latestWeight: number | null // kg, weight recorded on the most recent visit
+  lastDuration: number | null // seconds, duration of the most recent visit
+  visitsToday: number
+}
+
+/**
+ * Per-cat raw datapoints for integrations (Home Assistant). Cats are global to the
+ * install (not device-scoped), so this returns one entry per Pet.
+ *
+ * We deliberately expose only raw datapoints (latest weight, duration, last used,
+ * visits today). Trends/averages are left to Home Assistant, which keeps long-term
+ * statistics and can derive them from the weight sensor's history.
+ */
+export async function computePetStates(): Promise<PetLiveState[]> {
+  const pets = await prisma.pet.findMany()
+
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+
+  const result: PetLiveState[] = []
+  for (const pet of pets) {
+    const last = await prisma.litterEvent.findFirst({
+      where: { petId: pet.id, type: 'toileted' },
+      orderBy: { timestamp: 'desc' },
+    })
+
+    const visitsToday = await prisma.litterEvent.count({
+      where: { petId: pet.id, type: 'toileted', timestamp: { gte: today } },
+    })
+
+    result.push({
+      id: pet.id,
+      name: pet.name,
+      profileWeight: pet.weight,
+      lastUsedAt: last?.timestamp ?? null,
+      latestWeight: last?.weight ?? null,
+      lastDuration: last?.duration ?? null,
+      visitsToday,
+    })
+  }
+
+  return result
+}


### PR DESCRIPTION
## Summary
Turns Pawbby into a first-class Home Assistant device, going beyond the existing
outbound webhook notifications.

- **Fix:** `/api/external/*` was unreachable — the session-auth middleware only
  exempted `/api/auth` and `/api/webhook`, so the Bearer-key external API always
  401'd. Added an exemption so the API keys actually work.
- **REST:** new `GET /api/external/state` returns live device state + per-cat raw
  datapoints, reusing state-derivation extracted from `devices.ts` into
  `computeDeviceState()` / `computePetStates()`.
- **MQTT:** new bridge plugin publishes Home Assistant auto-discovery — box
  sensors + Flatten/Empty buttons, and one device per cat (last used, weight,
  duration, visits today). State pushed on `device:state-changed` + 30s refresh;
  command topics wired into the existing `tuya:action` pipeline.
- **UI/config:** MQTT settings card + connection test; docs in the in-app API
  page and README.

## Notes
- Adds new `User` MQTT columns → requires `npm run db:push` (Docker `CMD` and the
  auto-updater already run this).
- Adds one dependency: `mqtt`.
- "Clean" is intentionally not exposed — its Tuya payload is still unknown
  (no-op in `tuya-listener`); only flatten/empty are wired up.
- Weight/duration sensors use `state_class: measurement` so HA keeps long-term
  statistics; trends are left to HA rather than computed in-app.
