### PR TITLE
chore: dependency automation + Docker release pipeline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,43 @@
+version: 2
+updates:
+  # Application dependencies (Nuxt app lives in web/)
+  - package-ecosystem: "npm"
+    directory: "/web"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "npm"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(dev-deps)"
+    groups:
+      # Bundle low-risk minor/patch bumps into a single PR to reduce noise.
+      # Major upgrades stay as individual PRs for careful review.
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions used by the CI/release workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore(ci)"
+
+  # Base image for the Docker build (node:22-alpine)
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "chore(docker)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
           cache-dependency-path: 'web/package-lock.json'
           

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,93 @@
+name: Release
+
+# Reuses the project's existing versioning convention: the canonical version lives in
+# web/package.json (the in-app updater compares against main's copy of it). When that
+# version changes on main, we publish a matching Docker image and tag the release.
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - "web/package.json"
+  # Manual trigger for testing / re-publishing. `platforms` lets a manual run build
+  # amd64-only (fast, native) instead of the emulated multi-arch default.
+  workflow_dispatch:
+    inputs:
+      platforms:
+        description: "Platforms to build (comma-separated)"
+        default: "linux/amd64,linux/arm64"
+        type: string
+
+permissions:
+  contents: write   # create git tag + GitHub Release
+  packages: write   # push image to GitHub Container Registry
+
+jobs:
+  publish:
+    name: Publish Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Read version from web/package.json
+        id: ver
+        run: echo "version=$(node -p "require('./web/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Check whether this version was already released
+        id: check
+        run: |
+          if git rev-parse "v${{ steps.ver.outputs.version }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Tag v${{ steps.ver.outputs.version }} already exists — nothing to release."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up QEMU
+        if: steps.check.outputs.exists == 'false'
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        if: steps.check.outputs.exists == 'false'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        if: steps.check.outputs.exists == 'false'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive Docker tags/labels
+        if: steps.check.outputs.exists == 'false'
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=latest
+            type=raw,value=${{ steps.ver.outputs.version }}
+
+      - name: Build and push image
+        if: steps.check.outputs.exists == 'false'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ github.event.inputs.platforms || 'linux/amd64,linux/arm64' }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Create git tag and GitHub Release
+        if: steps.check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git tag "v${{ steps.ver.outputs.version }}"
+          git push origin "v${{ steps.ver.outputs.version }}"
+          gh release create "v${{ steps.ver.outputs.version }}" \
+            --title "v${{ steps.ver.outputs.version }}" \
+            --generate-notes

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,9 @@ WORKDIR /app/web
 # Install dependencies and build the Nuxt app
 RUN npm install
 RUN DATABASE_URL="file:./dev.db" npx prisma generate
-RUN npm run build
+# GOMAXPROCS=1 works around an esbuild (Go) memory-corruption crash when the
+# arm64 image is built under QEMU emulation (e.g. multi-arch release builds).
+RUN GOMAXPROCS=1 npm run build
 
 # Default environment variables
 ENV NODE_ENV=production


### PR DESCRIPTION
## What & why

Building the Docker image surfaces security warnings from outdated npm libraries, and there's currently no automated dependency maintenance, container-image publishing, or formal release process. This PR adds all three, designed to require **zero third-party apps and no extra secrets** — it works with GitHub-native features only.

## Changes

### 1. `.github/dependabot.yml` (new)
Weekly automated updates across three ecosystems:
- **npm** (`/web`) — minor+patch grouped into one PR, majors kept separate, `chore(deps)` commit prefix.
- **github-actions** — keeps workflow action versions current.
- **docker** — keeps the `node:22-alpine` base image current.

Once merged, GitHub's security-update flow auto-opens PRs for vulnerable dependencies.

### 2. `.github/workflows/ci.yml` (edit)
Bump `actions/setup-node` from Node 20 → **22** to match the Dockerfile/production runtime, so dependency-update PRs are validated against the real target. The existing PM2 + `docker compose build` jobs already run on every PR, so Dependabot PRs are build-validated automatically.

### 3. `.github/workflows/release.yml` (new)
Publishes a Docker image using the project's **existing versioning convention** — no new ritual. When `web/package.json`'s `version` changes on `main` (the same signal `server/api/update.get.ts` already uses), it:
- builds a multi-arch image (`linux/amd64,linux/arm64`),
- pushes `ghcr.io/<owner>/<repo>:<version>` + `:latest`,
- creates a `v<version>` git tag + a GitHub Release with generated notes.

A `git rev-parse` guard makes it idempotent: unrelated edits to `package.json`, or re-runs, are safe no-ops. A manual `workflow_dispatch` trigger (with a `platforms` input) is included for testing / re-publishing.

## One-time setup for the maintainer

The image push uses the built-in `GITHUB_TOKEN` (no secrets to add). The workflow declares `permissions: packages: write`; if the first release run fails with `denied: permission_denied: write_package`, enable **Settings → Actions → General → Workflow permissions → "Read and write"** once.

## Validation

The full pipeline was proven end-to-end on a fork before opening this PR:
- CI (Node 22, PM2 + docker build) passed on a PR.
- The release workflow built and pushed `:<version>` + `:latest` to GHCR, created the tag, and published the Release.
- The idempotency guard was confirmed (re-run skips build/push in seconds).