### PR TITLE
fix: Recover bin-full state when sensor reports collect_normal after …

### DIFF
--- a/web/app/pages/litter-box.vue
+++ b/web/app/pages/litter-box.vue
@@ -268,6 +268,24 @@
                 </svg>
               </div>
 
+              <div v-else-if="log.type === 'bin-full'"
+                class="w-8 h-8 rounded-lg bg-[#D84C4C]/20 flex items-center justify-center text-[#D84C4C]">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24"
+                  stroke="currentColor" stroke-width="2">
+                  <path stroke-linecap="round" stroke-linejoin="round"
+                    d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                </svg>
+              </div>
+
+              <div v-else-if="log.type === 'bin-normal'"
+                class="w-8 h-8 rounded-lg bg-green-500/20 flex items-center justify-center text-green-400">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24"
+                  stroke="currentColor" stroke-width="2">
+                  <path stroke-linecap="round" stroke-linejoin="round"
+                    d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+              </div>
+
               <div
                 v-else-if="(log.type === 'toileted' || log.type === 'quick-visit') && getPetInfo(log.petId)?.imageBase64"
                 class="w-8 h-8 rounded-lg overflow-hidden border border-white/10 bg-white/5">

--- a/web/server/api/events.ts
+++ b/web/server/api/events.ts
@@ -96,6 +96,10 @@ export default defineEventHandler(async (event) => {
       description = `${formatWeight(e.weight || 0)} of fresh litter was added to the box.`
     } else if (e.type === 'litter-removed') {
       description = `${formatWeight(e.weight || 0)} of litter was removed from the box.`
+    } else if (e.type === 'bin-normal') {
+      description = 'Waste bin level is back to normal.'
+    } else if (e.type === 'bin-full') {
+      description = 'Waste bin is full.'
     } else if (e.type === 'tuya-raw-data' && e.rawData) {
       // Try to parse the raw data to extract something readable if possible
       try {

--- a/web/server/plugins/tuya-listener.ts
+++ b/web/server/plugins/tuya-listener.ts
@@ -14,6 +14,13 @@ export default defineNitroPlugin((nitroApp) => {
     lastCatLeaveTime: number;
   }
 
+  const VISIT_STATUSES = new Set([
+    "cat_enter",
+    "cat_near",
+    "cat_near_leave",
+    "cat_leave",
+  ]);
+
   const activeDevices = new Map<string, any>();
   const retryTimeouts = new Map<string, any>();
   const pingIntervals = new Map<string, any>();
@@ -345,36 +352,59 @@ export default defineNitroPlugin((nitroApp) => {
               });
             }
 
-            // Quick visit detection: If it returns to idle but we were still tracking an unconfirmed visit
             if (
-              newStatus === "work_idle" &&
-              state.catEnteredAt &&
-              state.peakWeight > 0
+              newStatus === "collect_full" &&
+              state.currentStatus !== "collect_full"
             ) {
-              const durationSecs = Math.round(
-                (Date.now() - state.catEnteredAt) / 1000,
-              );
-              const weightInKg = state.peakWeight / 1000;
-
-              const matchedPetId = null;
-              
-              // We do NOT attempt to identify the pet for quick-visits, 
-              // because half a heavy cat leaning in looks identical to a small cat fully inside.
-
-              console.log(
-                `[PawID] Quick peek detected! Weight: ${weightInKg}kg, Duration: ${durationSecs}s.`,
-              );
-
               await prisma.litterEvent.create({
-                data: {
-                  type: "quick-visit",
-                  deviceId: config.id,
-                  petId: matchedPetId,
-                  weight: weightInKg,
-                  duration: durationSecs,
-                },
+                data: { type: "bin-full", deviceId: config.id },
               });
+              const user = await prisma.user.findFirst();
+              if (user) await dispatchWebhook(user, "🗑️ Waste bin is full and needs to be emptied.", "error");
+            }
+            if (
+              newStatus === "collect_normal" &&
+              state.currentStatus !== "collect_normal"
+            ) {
+              await prisma.litterEvent.create({
+                data: { type: "bin-normal", deviceId: config.id },
+              });
+              const user = await prisma.user.findFirst();
+              if (user) await dispatchWebhook(user, "✅ Waste bin is no longer full.", "error");
+            }
 
+            // Quick visit detection: If it returns to idle but we were still tracking an unconfirmed visit
+            if (newStatus === "work_idle" && state.catEnteredAt) {
+              if (state.peakWeight > 0) {
+                const durationSecs = Math.round(
+                  (Date.now() - state.catEnteredAt) / 1000,
+                );
+                const weightInKg = state.peakWeight / 1000;
+
+                const matchedPetId = null;
+
+                // We do NOT attempt to identify the pet for quick-visits,
+                // because half a heavy cat leaning in looks identical to a small cat fully inside.
+
+                console.log(
+                  `[PawID] Quick peek detected! Weight: ${weightInKg}kg, Duration: ${durationSecs}s.`,
+                );
+
+                await prisma.litterEvent.create({
+                  data: {
+                    type: "quick-visit",
+                    deviceId: config.id,
+                    petId: matchedPetId,
+                    weight: weightInKg,
+                    duration: durationSecs,
+                  },
+                });
+              }
+
+              // Always clear the visit window on return to idle, even when no
+              // weight sample ever came in - otherwise a stale catEnteredAt
+              // lingers in memory and gets wrongly attributed to a later,
+              // unrelated DP 107 confirmation.
               state.catEnteredAt = null;
               state.peakWeight = 0;
             }
@@ -402,20 +432,24 @@ export default defineNitroPlugin((nitroApp) => {
             stateChanged = true;
           }
 
-          // 4. Detect Cat Entry & Track Peak Weight
-          if (state.currentStatus === "cat_enter") {
-            if (!state.catEnteredAt) {
-              state.catEnteredAt = Date.now();
-              state.peakWeight = 0;
+          // 4. Detect Cat Entry & Track Peak Weight across the whole visit
+          // (device often flips past "cat_enter" before the next DP 112 sample arrives)
+          if (state.currentStatus === "cat_enter" && !state.catEnteredAt) {
+            state.catEnteredAt = Date.now();
+            state.peakWeight = 0;
+            stateChanged = true;
+          }
+
+          if (
+            state.catEnteredAt &&
+            VISIT_STATUSES.has(state.currentStatus) &&
+            dps["112"]
+          ) {
+            const currentWeight = dps["112"];
+            const catWeight = currentWeight - state.baseWeight;
+            if (catWeight > state.peakWeight) {
+              state.peakWeight = catWeight;
               stateChanged = true;
-            }
-            if (dps["112"]) {
-              const currentWeight = dps["112"];
-              const catWeight = currentWeight - state.baseWeight;
-              if (catWeight > state.peakWeight) {
-                state.peakWeight = catWeight;
-                stateChanged = true;
-              }
             }
           }
 

--- a/web/server/utils/deviceState.ts
+++ b/web/server/utils/deviceState.ts
@@ -104,12 +104,17 @@ export async function computeDeviceState(device: {
     where: { deviceId, type: 'bin-replaced' },
     orderBy: { timestamp: 'desc' },
   })
+  const latestCollectNormal = await prisma.litterEvent.findFirst({
+    where: { deviceId, type: 'tuya-raw-data', rawData: { contains: '"collect_normal"' } },
+    orderBy: { timestamp: 'desc' },
+  })
 
   let isBinFullState = false
   if (latestCollectFull) {
     const fullTime = latestCollectFull.timestamp.getTime()
     const replacedTime = latestBinReplaced ? latestBinReplaced.timestamp.getTime() : 0
-    if (fullTime > replacedTime) isBinFullState = true
+    const normalTime = latestCollectNormal ? latestCollectNormal.timestamp.getTime() : 0
+    if (fullTime > replacedTime && fullTime > normalTime) isBinFullState = true
   }
 
   // Check DP 116 for status
@@ -131,7 +136,7 @@ export async function computeDeviceState(device: {
         } else if (dp116 === 'collect_full') {
           status = 'Bin Full'
           wasteBin = 'Full'
-        } else if (dp116 !== 'work_idle') {
+        } else if (dp116 !== 'work_idle' && dp116 !== 'collect_normal') {
           status = 'Busy'
         }
       }


### PR DESCRIPTION
…collect_full

Occasionally the sensor misreports collect_full and later self-corrects with collect_normal. Track the latest collect_normal event alongside bin-replaced when deriving isBinFullState, and stop the DP116 status fallback from misclassifying collect_normal as Busy (which kept device controls disabled even after the waste bin badge showed Normal).